### PR TITLE
Fix wrong settings file in load_settings (settings are ignored)

### DIFF
--- a/DeleteCurrentFile.py
+++ b/DeleteCurrentFile.py
@@ -8,7 +8,7 @@ def plugin_loaded():
 
 def update_settings():
   global settings
-  settings = sublime.load_settings('ScopeAlways.sublime-settings')
+  settings = sublime.load_settings('DeleteCurrentFile.sublime-settings')
 
 
 class DeleteCurrentFileCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
The wrong settings file was loaded. This means settings are ignored, so prompts for actually deleting are never called ... oops.
