### PR TITLE
[Fixed] SideBarEnhancements conflict

### DIFF
--- a/DeleteCurrentFile.sublime-commands
+++ b/DeleteCurrentFile.sublime-commands
@@ -1,6 +1,6 @@
 [
   {
-    "caption": "File: Delete",
+    "caption": "DeleteCurrentFile: Delete File",
     "command": "delete_current_file"
   }
 ]


### PR DESCRIPTION
Users have same caption in [**SideBarEnhacements**](https://github.com/SideBarEnhancements-org/SideBarEnhancements/blob/st3/Commands.sublime-commands#L43-L44) — package of Top25 Sublime Text packages.

I think, that a good practice — package name in caption, because users knew, command of which package they run.

Thanks.